### PR TITLE
use absolute path to scripts directory

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -12,7 +12,7 @@ module.exports = (options) => {
     if (!options.script) {
       throw Error('Missing required input: options.script')
     }
-    const scriptsPath = pathJoin('scripts/')
+    const scriptsPath = pathJoin(__dirname, '../scripts/')
     const filePath = scriptsPath + options.script.split(' ')[0]
     if (!fileExists(filePath)) {
       throw Error(`File: ${filePath} does not exist`)


### PR DESCRIPTION
Hi there,
I noticed the scripts will not run if the server is started from a different directory (i.e. `node /some/path/dockerhub-webhook/index.js`). The problem is that the path to the scripts directory in `lib/run-script.js` is relative.